### PR TITLE
Gruppe Adler Zeus Modules: Loadouts festlegen

### DIFF
--- a/zeus_modules/cfgFunctions.hpp
+++ b/zeus_modules/cfgFunctions.hpp
@@ -1,0 +1,8 @@
+class prometheus_zeus {
+    class common {
+        file = zeus_modules\functions;
+
+        class setLoadoutModule_apply {};
+        class setLoadoutModule {};
+    };
+};

--- a/zeus_modules/functions/fn_setLoadoutModule.sqf
+++ b/zeus_modules/functions/fn_setLoadoutModule.sqf
@@ -1,0 +1,22 @@
+params ["_position","_selObject"];
+
+private _sides = [WEST,EAST,INDEPENDENT,CIVILIAN];
+private _sideStr = _sides apply {str _x};
+private _defaultSide = (_sides find (side _selObject)) max 0;
+private _loadouts = "true" configClasses (missionConfigFile >> "Loadouts" >> "Faction");
+private _loadoutsStr = _loadouts apply {configName _x};
+
+private _result = ["Loadouts festlegen",
+[
+    ["Seite", _sideStr, _defaultSide],
+    ["Loadout", _loadoutsStr, 0]
+]] call Ares_fnc_showChooseDialog;
+
+if (count _result == 0) exitWith {};
+
+_result params ["_sideID","_loadoutID"];
+private _selSide = _sides select _sideID;
+private _sidePrefix = ["BLU_F","OPF_F","IND_F","CIV_F"] select _sideID;
+private _selLoadout = _loadoutsStr select _loadoutID;
+
+[_sidePrefix, _selLoadout] remoteExec ["prometheus_zeus_fnc_setLoadoutModule_apply",0,true];

--- a/zeus_modules/functions/fn_setLoadoutModule_apply.sqf
+++ b/zeus_modules/functions/fn_setLoadoutModule_apply.sqf
@@ -1,0 +1,8 @@
+params ["_sidePrefix", "_selLoadout"];
+
+[_sidePrefix, _selLoadout] call GRAD_Loadout_fnc_FactionSetLoadout;
+private _allLocalUnits = allUnits select {local _x};
+{
+    [_x] call GRAD_Loadout_fnc_doLoadoutForUnit;
+    false
+} count _allLocalUnits;

--- a/zeus_modules/initZeusModules.sqf
+++ b/zeus_modules/initZeusModules.sqf
@@ -1,0 +1,3 @@
+#define CATEGORYNAME        "Gruppe Adler"
+
+[CATEGORYNAME,"Loadouts festlegen",{_this call prometheus_zeus_fnc_setLoadoutModule}] call ares_fnc_registerCustomModule;


### PR DESCRIPTION
* erster Anfang für eigene Module, ich denke da können wir noch kreativ werden
* Kategoriename: "Gruppe Adler"
* Funktionspräfix: "prometheus_zeus" (?)
* fügt das "Loadouts festlegen" Modul hinzu
  - Legt Loadouts für alle BLU_F/OPF_F/IND_F/CIV_F Einheiten fest und wendet sie an (Spieler und KI)

Ist hier im PR noch nicht in die Mission eingebunden, da wir erst grad-loadout und grad-factions brauchen. Zum Einbinden:

init.sqf  
`[] execVM "zeus_modules\initZeusModules.sqf";`

cfgFunctions
`#include "zeus_modules\cfgFunctions.hpp"`

[![](http://i.imgur.com/vkaZTMN.jpg)](http://i.imgur.com/vkaZTMN.jpg)